### PR TITLE
feat: implement minimal working version of `kvdb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Use "kvdb [command] --help" for more information about a command.
 ```
 
 ## Features
-- `kvdb` supports valid utf8 strings not containing path delimiters
-  ('/', '\') as keys and values.
+- `kvdb` supports valid `utf-8` strings not containing path delimiters
+  (`/`, `\`) as keys and values.
 - By design, `kvdb` does not support empty values for keys. This was done to
   reduce confusion. To unset a key, simple delete it.
 - Kvdb operations are atomic. Multiple processes can safely invoke `kvdb` to

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# kvdb
-A lightweight, embedded key-value store in Golang
+# KVDB
+
+`kvdb` is a lightweight, filesystem-backed, cli-driven key-value store written
+in Go. This project started as a submission to a 4-hour coding challenge.
+
+## Get Started & Usage
+
+To get started, clone this repository and install the `kvdb` CLI using
+`go install`
+
+```console
+$ git clone github.com/adowair/kvdb
+...
+$ cd kvdb
+$ go install .
+$ kvdb --help
+Kvdb is a lightweight, filesystem-backed key-value store written in Go.
+By default, kvdb uses the current directory to store data. To get started:
+
+        kvdb set <key> <value>
+        kvdb get <key>
+
+Usage:
+  kvdb [command]
+
+Available Commands:
+  del         Delete a key
+  get         Get the value for a key
+  help        Help about any command
+  set         Set the value for a key
+  ts          Get the created and last-modified timestamps for a key
+
+Flags:
+  -h, --help   help for kvdb
+
+Use "kvdb [command] --help" for more information about a command.
+```
+
+## Features
+- `kvdb` supports valid utf8 strings not containing path delimiters
+  ('/', '\') as keys and values.
+- By design, `kvdb` does not support empty values for keys. This was done to
+  reduce confusion. To unset a key, simple delete it.
+- Kvdb operations are atomic. Multiple processes can safely invoke `kvdb` to
+  safely read and write the same keys.
+
+## Possible Improvements
+- Use shared (not exclusive) locks for reads.
+- Support nested keys (i.e. "key/subkey").
+- Implement configurable database location, backed by a config file.
+- Lazily read data files, saving some work when only timestamps are requested.
+- Retain key's metadata when it is deleted, "remembering" first-set timestamps.

--- a/cmd/del.go
+++ b/cmd/del.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// delCmd represents the del command
+var delCmd = &cobra.Command{
+	Use:   "del",
+	Short: "Delete a key",
+	Long: `Delete a key from the database. This removes the corresponding files
+from the underlying filesystem.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("del called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(delCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// delCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// delCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/del.go
+++ b/cmd/del.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/adowair/kvdb/kv"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +13,15 @@ var delCmd = &cobra.Command{
 	Short: "Delete a key",
 	Long: `Delete a key from the database. This removes the corresponding files
 from the underlying filesystem.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("del called")
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		if err := kv.Delete(key); err != nil {
+			return err
+		}
+
+		fmt.Printf("Deleted %s\n", key)
+		return nil
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get the value for a key",
+	Long: `Get the value of a key in the database.
+If the key does not exist, an error is returned.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("get called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/adowair/kvdb/kv"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +13,16 @@ var getCmd = &cobra.Command{
 	Short: "Get the value for a key",
 	Long: `Get the value of a key in the database.
 If the key does not exist, an error is returned.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("get called")
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		val, err := kv.Get(key)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Key %s: %s\n", key, val)
+		return nil
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "kvdb",
+	Short: "A lightweight, embedded key-value store",
+	Long: `
+Kvdb is a lightweight, filesystem-backed key-value store written in Go.
+By default, kvdb uses the current directory to store data. To get started:
+
+	kvdb set <key> <value>
+	kvdb get <key>
+`,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
+	SilenceUsage: true,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.kvdb.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/adowair/kvdb/kv"
 	"github.com/spf13/cobra"
@@ -17,7 +18,7 @@ If the key already exists, its old value is overwritten.`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		key, val := args[0], args[1]
-		if err := kv.Set(key, val); err != nil {
+		if err := kv.Set(key, val, time.Now()); err != nil {
 			return err
 		}
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// setCmd represents the set command
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set the value for a key",
+	Long: `Set the value of a key in the database.
+If the key does not exist, it is created.
+If the key already exists, its old value is overwritten.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("set called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(setCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// setCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// setCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/adowair/kvdb/kv"
 	"github.com/spf13/cobra"
 )
 
@@ -13,8 +14,15 @@ var setCmd = &cobra.Command{
 	Long: `Set the value of a key in the database.
 If the key does not exist, it is created.
 If the key already exists, its old value is overwritten.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("set called")
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key, val := args[0], args[1]
+		if err := kv.Set(key, val); err != nil {
+			return err
+		}
+
+		fmt.Printf("Set %s <= %s\n", key, val)
+		return nil
 	},
 }
 

--- a/cmd/ts.go
+++ b/cmd/ts.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// tsCmd represents the ts command
+var tsCmd = &cobra.Command{
+	Use:   "ts",
+	Short: "Get the created and last-modified timestamps for a key",
+	Long: `Get the times this key was first and last set
+These timestamps are durable--moving a database folder will not affect them.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("ts called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(tsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// tsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// tsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/ts.go
+++ b/cmd/ts.go
@@ -3,8 +3,11 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/adowair/kvdb/kv"
 	"github.com/spf13/cobra"
 )
+
+const timeFormat = "2006-01-02 15:04:05"
 
 // tsCmd represents the ts command
 var tsCmd = &cobra.Command{
@@ -12,8 +15,18 @@ var tsCmd = &cobra.Command{
 	Short: "Get the created and last-modified timestamps for a key",
 	Long: `Get the times this key was first and last set
 These timestamps are durable--moving a database folder will not affect them.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("ts called")
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		first, last, err := kv.Timestamps(key)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Key %s:\n", key)
+		fmt.Printf("  First set on %s\n", first.Format(timeFormat))
+		fmt.Printf("  Last set on  %s\n", last.Format(timeFormat))
+		return nil
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/adowair/kvdb
 
 go 1.17
+
+require github.com/spf13/cobra v1.7.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,17 @@
 module github.com/adowair/kvdb
 
-go 1.17
+go 1.18
 
 require github.com/spf13/cobra v1.7.0
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.4
 )

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,18 @@
 module github.com/adowair/kvdb
 
-go 1.18
+go 1.21
 
 require github.com/spf13/cobra v1.7.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
+	github.com/gofrs/flock v0.8.1
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,17 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -12,6 +14,8 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/kv/ops.go
+++ b/kv/ops.go
@@ -9,7 +9,7 @@ func Get(key string) (string, error) {
 	return "", errors.ErrUnsupported
 }
 
-func Set(key, val string) error {
+func Set(key, val string, now time.Time) error {
 	return errors.ErrUnsupported
 }
 

--- a/kv/ops.go
+++ b/kv/ops.go
@@ -1,0 +1,22 @@
+package kv
+
+import (
+	"errors"
+	"time"
+)
+
+func Get(key string) (string, error) {
+	return "", errors.ErrUnsupported
+}
+
+func Set(key, val string) error {
+	return errors.ErrUnsupported
+}
+
+func Timestamps(key string) (first, last time.Time, err error) {
+	return time.Time{}, time.Time{}, errors.ErrUnsupported
+}
+
+func Delete(key string) error {
+	return errors.ErrUnsupported
+}

--- a/kv/ops.go
+++ b/kv/ops.go
@@ -2,21 +2,50 @@ package kv
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
 func Get(key string) (string, error) {
-	return "", errors.ErrUnsupported
+	entry, err := read(key)
+	if err != nil {
+		return "", fmt.Errorf("error getting key %s, %w", key, err)
+	}
+	return entry.Value, nil
 }
 
 func Set(key, val string, now time.Time) error {
-	return errors.ErrUnsupported
+	entry := Entry{
+		LastEdited: now,
+		Value:      val,
+	}
+
+	if oldEntry, err := read(key); errors.Is(err, ErrNotExist) {
+		entry.FirstEdited = entry.LastEdited
+	} else {
+		entry.FirstEdited = oldEntry.FirstEdited
+	}
+
+	err := write(key, &entry)
+	if err != nil {
+		return fmt.Errorf("error setting key %s, %w", key, err)
+	}
+	return nil
 }
 
 func Timestamps(key string) (first, last time.Time, err error) {
-	return time.Time{}, time.Time{}, errors.ErrUnsupported
+	entry, err := read(key)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf(
+			"error getting timestamps for %s, %w", key, err)
+	}
+	return entry.FirstEdited, entry.LastEdited, nil
 }
 
 func Delete(key string) error {
-	return errors.ErrUnsupported
+	err := delete(key)
+	if err != nil {
+		return fmt.Errorf("error deleting key %s, %w", key, err)
+	}
+	return nil
 }

--- a/kv/ops_test.go
+++ b/kv/ops_test.go
@@ -1,0 +1,80 @@
+package kv_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/adowair/kvdb/kv"
+	"github.com/stretchr/testify/assert"
+)
+
+// testcase runs as a subtest of the top-level test in this file. Each
+// testcase consists of a series of operations to be executed. The returns
+// from each command are compared to some expected values.
+type testcase struct {
+	name  string
+	steps []step
+}
+
+// step encapsulates the run of a single command, its expected outputs
+// and the assertion that its outputs match the expectation.
+type step struct {
+	run func(*testing.T, *expReturns)
+	expReturns
+}
+
+// expReturns encapsulates possible returns for any operation. All fields
+// are optional depending on the operation being tested, except for `expError`.
+type expReturns struct {
+	expError    error
+	expValue    string
+	expFirstSet time.Time
+	expLastSet  time.Time
+}
+
+func testGet(key string) func(*testing.T, *expReturns) {
+	return func(t *testing.T, r *expReturns) {
+		ret, err := kv.Get(key)
+		assert.ErrorIs(t, err, r.expError)
+		assert.Equal(t, ret, r.expValue)
+	}
+}
+
+func testSet(key string, val string) func(*testing.T, *expReturns) {
+	return func(t *testing.T, r *expReturns) {
+		err := kv.Set(key, val)
+		assert.ErrorIs(t, err, r.expError)
+	}
+}
+
+func testTimestamp(key string) func(*testing.T, *expReturns) {
+	return func(t *testing.T, r *expReturns) {
+		first, last, err := kv.Timestamps(key)
+		assert.ErrorIs(t, err, r.expError)
+		assert.Equal(t, first, r.expFirstSet)
+		assert.Equal(t, last, r.expLastSet)
+	}
+}
+
+func testDelete(key string) func(*testing.T, *expReturns) {
+	return func(t *testing.T, r *expReturns) {
+		err := kv.Delete(key)
+		assert.ErrorIs(t, err, r.expError)
+	}
+}
+
+func TestKVOps(t *testing.T) {
+	for _, tc := range []testcase{} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			assert.NoError(t, os.Chdir(dir))
+			for i, step := range tc.steps {
+				t.Run(fmt.Sprintf("TestStep%d", i), func(t *testing.T) {
+					step.run(t, &step.expReturns)
+				})
+			}
+		})
+	}
+}

--- a/kv/ops_test.go
+++ b/kv/ops_test.go
@@ -12,7 +12,7 @@ import (
 
 // testcase runs as a subtest of the top-level test in this file. Each
 // testcase consists of a series of operations to be executed. The returns
-// from each command are compared to some expected values.
+// from each operation are compared to some expected values.
 type testcase struct {
 	name  string
 	steps []step

--- a/kv/ops_test.go
+++ b/kv/ops_test.go
@@ -28,45 +28,165 @@ type step struct {
 // expReturns encapsulates possible returns for any operation. All fields
 // are optional depending on the operation being tested, except for `expError`.
 type expReturns struct {
-	expError    error
-	expValue    string
-	expFirstSet time.Time
-	expLastSet  time.Time
+	err      error
+	value    string
+	firstSet time.Time
+	lastSet  time.Time
 }
+
+var (
+	time0 = time.Unix(0, 0)
+	time1 = time.Unix(1, 0)
+)
 
 func testGet(key string) func(*testing.T, *expReturns) {
 	return func(t *testing.T, r *expReturns) {
-		ret, err := kv.Get(key)
-		assert.ErrorIs(t, err, r.expError)
-		assert.Equal(t, ret, r.expValue)
+		value, err := kv.Get(key)
+		assert.ErrorIs(t, err, r.err)
+		assert.Equal(t, r.value, value)
 	}
 }
 
-func testSet(key string, val string) func(*testing.T, *expReturns) {
+func testSet(key, val string, now time.Time) func(*testing.T, *expReturns) {
 	return func(t *testing.T, r *expReturns) {
-		err := kv.Set(key, val)
-		assert.ErrorIs(t, err, r.expError)
+		err := kv.Set(key, val, now)
+		assert.ErrorIs(t, err, r.err)
 	}
 }
 
 func testTimestamp(key string) func(*testing.T, *expReturns) {
 	return func(t *testing.T, r *expReturns) {
-		first, last, err := kv.Timestamps(key)
-		assert.ErrorIs(t, err, r.expError)
-		assert.Equal(t, first, r.expFirstSet)
-		assert.Equal(t, last, r.expLastSet)
+		firstSet, lastSet, err := kv.Timestamps(key)
+		assert.ErrorIs(t, err, r.err)
+		assert.Equal(t, r.firstSet, firstSet, "firstSet")
+		assert.Equal(t, r.lastSet, lastSet, "lastSet")
 	}
 }
 
 func testDelete(key string) func(*testing.T, *expReturns) {
 	return func(t *testing.T, r *expReturns) {
 		err := kv.Delete(key)
-		assert.ErrorIs(t, err, r.expError)
+		assert.ErrorIs(t, err, r.err)
 	}
 }
 
 func TestKVOps(t *testing.T) {
-	for _, tc := range []testcase{} {
+	for _, tc := range []testcase{
+		{
+			name: "TestGetNotExist",
+			steps: []step{
+				{
+					run:        testGet("a"),
+					expReturns: expReturns{err: kv.ErrNotExist},
+				},
+			},
+		},
+		{
+			name: "TestDoubleGetNotExist",
+			steps: []step{
+				{
+					run:        testGet("a"),
+					expReturns: expReturns{err: kv.ErrNotExist},
+				},
+				{
+					run:        testGet("b"),
+					expReturns: expReturns{err: kv.ErrNotExist},
+				},
+			},
+		},
+		{
+			name: "TestSetGet",
+			steps: []step{
+				{
+					run:        testSet("a", "12", time0),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testGet("a"),
+					expReturns: expReturns{err: nil, value: "12"},
+				},
+				{
+					run:        testSet("b", "13", time0),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testGet("b"),
+					expReturns: expReturns{err: nil, value: "13"},
+				},
+				{
+					run:        testSet("a", "14", time1),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testGet("a"),
+					expReturns: expReturns{err: nil, value: "14"},
+				},
+			},
+		},
+		{
+			name: "TestSetTS",
+			steps: []step{
+				{
+					run:        testSet("a", "12", time0),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testTimestamp("a"),
+					expReturns: expReturns{err: nil, firstSet: time0, lastSet: time0},
+				},
+				{
+					run:        testSet("b", "13", time1),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testTimestamp("b"),
+					expReturns: expReturns{err: nil, firstSet: time1, lastSet: time1},
+				},
+				{
+					run:        testSet("a", "13", time1),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testTimestamp("a"),
+					expReturns: expReturns{err: nil, firstSet: time0, lastSet: time1},
+				},
+			},
+		},
+		{
+			name: "TestDeleteTS",
+			steps: []step{
+				{
+					run:        testSet("a", "12", time0),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testDelete("a"),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testTimestamp("a"),
+					expReturns: expReturns{err: kv.ErrNotExist},
+				},
+			},
+		},
+		{
+			name: "TestDeleteGet",
+			steps: []step{
+				{
+					run:        testSet("a", "12", time0),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testDelete("a"),
+					expReturns: expReturns{err: nil},
+				},
+				{
+					run:        testGet("a"),
+					expReturns: expReturns{err: kv.ErrNotExist},
+				},
+			},
+		},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			assert.NoError(t, os.Chdir(dir))

--- a/kv/util.go
+++ b/kv/util.go
@@ -1,0 +1,136 @@
+package kv
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// ErrNotExist is returned when attempting to perform an operation on a key
+// which does not exist.
+var ErrNotExist = errors.New("key does not exist")
+
+// ErrBadFormat is returned when a read file contains data which cannot be
+// properly parsed into an Entry.
+var ErrBadFormat = errors.New("malformed data")
+
+type Entry struct {
+	FirstEdited time.Time
+	LastEdited  time.Time
+	Value       string
+}
+
+// delimiter is the internal symbol used to separate fields of an Entry
+// in its encoded, on-disk format.
+const delimiter = ','
+
+// read is a wrapper around readFrom() which reads a key
+// from the current directory.
+func read(key string) (*Entry, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(wd, key)
+	return readFrom(path)
+}
+
+// readFrom is an internal function that gets the contents of a file in db, and
+// parses it into an Entry if possible. This function is exposed to be testable
+// and swappable with other implementations in the future.
+func readFrom(path string) (*Entry, error) {
+	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrNotExist
+	} else if err != nil {
+		return nil, err
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := bytes.SplitN(b, []byte{delimiter}, 3)
+	if len(raw) != 3 {
+		return nil, fmt.Errorf("%w, missing value or timestamp %q", ErrBadFormat, b)
+	}
+
+	firstEdited, err := strconv.ParseInt(string(raw[0]), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("%w, could not parse first-set timestamp %q, %w",
+			ErrBadFormat, raw[0], err)
+	}
+
+	lastEdited, err := strconv.ParseInt(string(raw[1]), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("%w, could not parse last-set timestamp %q, %w",
+			ErrBadFormat, raw[1], err)
+	}
+
+	value := raw[2]
+	if len(value) == 0 {
+		return nil, fmt.Errorf("%w, missing value %q", ErrBadFormat, b)
+	}
+
+	return &Entry{
+		FirstEdited: time.Unix(firstEdited, 0),
+		LastEdited:  time.Unix(lastEdited, 0),
+		Value:       string(value),
+	}, nil
+}
+
+// write is a wrapper around writeTo() which writes a key to the current
+// directory.
+func write(key string, entry *Entry) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(wd, key)
+	return writeTo(path, entry)
+}
+
+// readFrom is an internal function that serializes an Entry, and then
+// writes it to db in a file named key. This function is exposed to be testable
+// and swappable with other implementations in the future.
+func writeTo(path string, entry *Entry) error {
+	if len(entry.Value) == 0 {
+		return fmt.Errorf("%w, storing empty \"\" is not allowed", ErrBadFormat)
+	}
+
+	data := fmt.Sprintf(
+		"%d%c%d%c%s",
+		entry.FirstEdited.Unix(),
+		delimiter,
+		entry.LastEdited.Unix(),
+		delimiter,
+		entry.Value)
+
+	return os.WriteFile(path, []byte(data), os.ModePerm)
+}
+
+func delete(key string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(wd, key)
+	return deleteFile(path)
+}
+
+func deleteFile(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	return err
+}

--- a/kv/util_test.go
+++ b/kv/util_test.go
@@ -1,0 +1,227 @@
+package kv
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testcase struct {
+	name        string
+	initialData map[string]string
+	key         string
+	expError    error
+	targetEntry *Entry
+	finalData   map[string]string
+}
+
+func setupTestDB(t *testing.T, entries map[string]string) string {
+	dir := t.TempDir()
+	assert.NoError(t, os.Chdir(dir))
+	for key, value := range entries {
+		os.WriteFile(key, []byte(value), fs.ModePerm)
+	}
+	return dir
+}
+
+func checkTestDB(t *testing.T, path string, entries map[string]string) {
+	dir, err := os.ReadDir(path)
+	assert.NoError(t, err)
+	assert.Equal(t, len(entries), len(dir))
+	for key, data := range entries {
+		assert.FileExists(t, key)
+		actual, err := os.ReadFile(key)
+		assert.NoError(t, err)
+		assert.Equal(t, data, string(actual))
+	}
+}
+
+func TestRead(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name:        "TestReadOK",
+			key:         "foo",
+			initialData: map[string]string{"foo": "0,0,bar"},
+			expError:    nil,
+			targetEntry: &Entry{
+				Value:       "bar",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(0, 0),
+			},
+			finalData: map[string]string{"foo": "0,0,bar"},
+		},
+		{
+			name:        "TestReadEmptyValue",
+			key:         "foo",
+			initialData: map[string]string{"foo": "0,0,"},
+			expError:    ErrBadFormat,
+			targetEntry: nil,
+			finalData:   map[string]string{"foo": "0,0,"},
+		},
+		{
+			name:        "TestReadNotExist",
+			key:         "foo",
+			initialData: nil,
+			expError:    ErrNotExist,
+			targetEntry: nil,
+			finalData:   nil,
+		},
+		{
+			name:        "TestReadDelimiterInValue",
+			key:         "foo",
+			initialData: map[string]string{"foo": "0,0,ba,r"},
+			expError:    nil,
+			targetEntry: &Entry{
+				Value:       "ba,r",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(0, 0),
+			},
+			finalData: map[string]string{"foo": "0,0,ba,r"},
+		},
+		{
+			name:        "TestReadNoValue",
+			key:         "foo",
+			initialData: map[string]string{"foo": "0,0"},
+			expError:    ErrBadFormat,
+			targetEntry: nil,
+			finalData:   map[string]string{"foo": "0,0"},
+		},
+		{
+			name:        "TestReadNothing",
+			key:         "foo",
+			initialData: map[string]string{"foo": ""},
+			expError:    ErrBadFormat,
+			targetEntry: nil,
+			finalData:   map[string]string{"foo": ""},
+		},
+		{
+			name:        "TestReadNotTimestamp",
+			key:         "foo",
+			initialData: map[string]string{"foo": "0,alpha,bar"},
+			expError:    ErrBadFormat,
+			targetEntry: nil,
+			finalData:   map[string]string{"foo": "0,alpha,bar"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := setupTestDB(t, tc.initialData)
+
+			entry, err := read(tc.key)
+			assert.Equal(t, tc.targetEntry, entry)
+			assert.ErrorIs(t, err, tc.expError)
+
+			checkTestDB(t, dir, tc.finalData)
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name:        "TestWriteOK",
+			initialData: nil,
+			key:         "foo",
+			targetEntry: &Entry{
+				Value:       "bar",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(1, 0),
+			},
+			expError:  nil,
+			finalData: map[string]string{"foo": "0,1,bar"},
+		},
+		{
+			name:        "TestOverWrite",
+			initialData: map[string]string{"foo": "0,0,bar"},
+			key:         "foo",
+			targetEntry: &Entry{
+				Value:       "baz",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(1, 0),
+			},
+			expError:  nil,
+			finalData: map[string]string{"foo": "0,1,baz"},
+		},
+		{
+			name:        "TestWriteEmptyValue",
+			initialData: nil,
+			key:         "foo",
+			targetEntry: &Entry{
+				Value:       "",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(1, 0),
+			},
+			expError:  ErrBadFormat,
+			finalData: nil,
+		},
+		{
+			name:        "TestOverWriteEmptyValue",
+			initialData: map[string]string{"foo": "0,0,bar"},
+			key:         "foo",
+			targetEntry: &Entry{
+				Value:       "",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(1, 0),
+			},
+			expError:  ErrBadFormat,
+			finalData: map[string]string{"foo": "0,0,bar"},
+		},
+		{
+			name:        "TestWriteEmptyEntry",
+			initialData: nil,
+			key:         "foo",
+			targetEntry: &Entry{},
+			expError:    ErrBadFormat,
+			finalData:   nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := setupTestDB(t, tc.initialData)
+
+			err := write(tc.key, tc.targetEntry)
+			assert.ErrorIs(t, err, tc.expError)
+
+			checkTestDB(t, dir, tc.finalData)
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name:        "TestDeleteOK",
+			initialData: map[string]string{"foo": "0,1,bar"},
+			key:         "foo",
+			targetEntry: &Entry{
+				Value:       "bar",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(1, 0),
+			},
+			expError:  nil,
+			finalData: nil,
+		},
+		{
+			name:        "TestIdempotentDelete",
+			initialData: nil,
+			key:         "foo",
+			targetEntry: &Entry{
+				Value:       "bar",
+				FirstEdited: time.Unix(0, 0),
+				LastEdited:  time.Unix(1, 0),
+			},
+			expError:  nil,
+			finalData: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testDir := setupTestDB(t, tc.initialData)
+
+			err := delete(tc.key)
+			assert.ErrorIs(t, err, tc.expError)
+
+			checkTestDB(t, testDir, tc.finalData)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
+/*
+Copyright © 2023 Ali Dowair <adoair@umich.edu>
+
+*/
 package main
 
-import "fmt"
+import "github.com/adowair/kvdb/cmd"
 
 func main() {
-	fmt.Println("Hello World!")
+	cmd.Execute()
 }


### PR DESCRIPTION
This pull-request implements an MVP of the `kvdb` CLI, complete with unit tests.
This version of the CLI can only store and read keys from the current working
directory, and supports four operations: set, get, delete keys, and get first
and last-edited timestamps for a key. 