### PR TITLE
build: setup semantic release versioning workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,23 @@
+# This workflow will validate pull request titles according to the conventional commit standard
+# For more information see: https://github.com/marketplace/actions/semantic-pull-request
+
+name: Lint PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+# This workflow will release the project according to the conventional commit standard
+# For more information see: https://github.com/marketplace/actions/release-please-action
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: kvdb
+            


### PR DESCRIPTION
This commit will add workflows to automate project releases (and enforce PR
title requirements) according to the Conventional Commits standard
(see https://www.conventionalcommits.org/en/v1.0.0/).