### PR TITLE
chore: fixup release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
-          release-type: node
+          release-type: go
           package-name: kvdb
-            
+          pull-request-header: Automated Release PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2023-11-01)
+
+
+### Features
+
+* implement minimal working version of `kvdb` ([#1](https://github.com/adowair/kvdb/issues/1)) ([708dc0b](https://github.com/adowair/kvdb/commit/708dc0b57df984a9598e58bac4a23015436e714f))


### PR DESCRIPTION
This commit will fixup the release-please action to release a Go project instead of a node project, along with a minor style improvement