### PR TITLE
chore: fix release workflow for go project

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
-          release-type: node
+          release-type: go
           package-name: kvdb
-            
+          prerelease: true
+          pull-request-header: Automated Release PR


### PR DESCRIPTION
This commit will fix up the release-please action to release a Go project instead of a Node project, along with some style improvements